### PR TITLE
update validation for cert

### DIFF
--- a/docs/70_PHP-client/60_Plugins/20_Checks/cert.md
+++ b/docs/70_PHP-client/60_Plugins/20_Checks/cert.md
@@ -28,12 +28,14 @@ $oMonitor->addCheck(
 
 | key      | type     | description
 |---       |---       |---
-|url       |(string)  |url to connect check i.e. <https://example.com:3000>; default: own protocol + server of your webapp
+|url *     |(string)  |url to connect check i.e. <https://example.com:3000>; default: own protocol + server of your webapp
 |verify    |(boolean) |optional: flag verify certificate; default = true
 |warning   |(integer) |optional: count of days to warn; default=21
 |critical  |(integer) |optional: count of days to raise critical; default=5
 
-I recommend to set verify to *true*. If you should get a warning like
+(*) The field url is required for fon non PHP webs eg. when using amcli client.
+
+I recommend to leave verify on *true*. If you should get a warning like
 
 ```text
 PHP Warning:  stream_socket_client(): SSL operation failed with code 1. OpenSSL Error messages:

--- a/public_html/client/plugins/checks/cert.php
+++ b/public_html/client/plugins/checks/cert.php
@@ -57,7 +57,7 @@ class checkCert extends appmonitorcheck
             'url' => [
                 'type' => 'string',
                 'required' => true,
-                'description' => 'Url to check https://[server}[:{port}] or ssl://[server}[:{port}]',
+                'description' => 'Url to check https://[server}[:{port}] or ssl://[server}[:{port}]; autodetected on webserver with php but required on cli',
                 'default' => null,
                 'regex'=>'/^(https|ssl):\/\/[^\s]+/',
                 'example' => '',
@@ -85,6 +85,18 @@ class checkCert extends appmonitorcheck
             ],
         ],
     ];
+
+    /**
+     * Override explain()
+     * If https is used, url is not required because it can be autodetected from $_SERVER
+     */
+    public function explain(): array
+    {
+        if($_SERVER['HTTPS']??false && $_SERVER['SERVER_NAME']??false){
+            $this->_aDoc['parameters']['url']['required']=false;
+        }
+        return $this->_aDoc;
+    }
 
     /**
      * Get default group of this check


### PR DESCRIPTION
For a ssl certicate check the field "url" was set to required in the validation rules.
But 
* PHP websites used this check without url - there it is not required
* For Non-PHP webs it must be required

The validation rule is now dynamic and detects if it is in PHP Web environment.